### PR TITLE
Add 'tobiiDoClick' to config

### DIFF
--- a/src/com/esotericsoftware/clippy/Config.java
+++ b/src/com/esotericsoftware/clippy/Config.java
@@ -108,6 +108,7 @@ public class Config {
 	public ArrayList<PhilipsHueLights> philipsHue;
 
 	public boolean tobiiEnabled;
+	public boolean tobiiDoClick = true;
 	public String tobiiClickHotkey = "CAPS_LOCK";
 	public float tobiiHeadSensitivityX = 6;
 	public float tobiiHeadSensitivityY = 8;

--- a/src/com/esotericsoftware/clippy/Tobii.java
+++ b/src/com/esotericsoftware/clippy/Tobii.java
@@ -226,7 +226,11 @@ public class Tobii {
 					}
 					setGridOffset(gazeStartX, gazeStartY, mouse.x - gazeStartX, mouse.y - gazeStartY);
 				}
-				robot.mousePress(InputEvent.BUTTON1_MASK);
+				
+				//Send mouse click if configured.
+				if( clippy.config.tobiiDoClick ) { 
+					robot.mousePress(InputEvent.BUTTON1_MASK);
+				}
 				mouseDownTime = System.currentTimeMillis();
 			}
 			return false;


### PR DESCRIPTION
Adds the ability to disable the sending of a mouse click when the tobii hotkey is released.

I sometimes want to move the cursor without clicking, so I have made some small changes allowing this kind of behaviour if desired. The default remains as before, you have to add the line:

`tobiiDoClick: false`

to config.json to be able to see the difference.

I also noticed someone else was after this in issue #14 